### PR TITLE
Order member list by join date

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Currently we are hosting the following projects:
 Contributions are more than welcome! If you have any suggestions, ideas, or projects you would like to host under this organization, don't hesitate to contact us!
 
 ## Members
-The following people are currently members of this organization (alphabetically):
+The following people are currently members of this organization:
 
-- Jiří Zárevúcky ([@le-jzr](https://github.com/le-jzr)): Contributor to [helenos](https://github.com/HelenOS/helenos).
-- Lachlan Sneff ([@lachlansneff](https://github.com/lachlansneff)): Author of [nebulet os](https://github.com/nebulet/nebulet).
 - Philipp Oppermann ([@phil-opp](https://github.com/phil-opp)): Author of the [“Writing an OS in Rust”](https://os.phil-opp.com/) series.
+- Lachlan Sneff ([@lachlansneff](https://github.com/lachlansneff)): Author of [nebulet os](https://github.com/nebulet/nebulet).
 - Rob Gries ([@robert-w-gries](https://github.com/robert-w-gries)): Author of [rxinu](https://github.com/robert-w-gries/rxinu), a Rust implementation of the Xinu educational operating system.
+- Jiří Zárevúcky ([@le-jzr](https://github.com/le-jzr)): Contributor to [helenos](https://github.com/HelenOS/helenos).
 - Joel Wejdenstal ([@xacrimon](https://github.com/xacrimon)): Author of the [skp](https://github.com/xacrimon/skp) project.
 - Isaac Woods ([@IsaacWoods](https://github.com/IsaacWoods)): Author of [Pebble OS](https://github.com/pebble-os/pebble)


### PR DESCRIPTION
Chronological order makes more sense than alphabetical, because it's unclear whether we should sort by first name, last name, or username. Also, new members can just add theirselves at the end of the list.