### PR TITLE
Add uefi-rs crate to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Currently we are hosting the following projects:
 - [`bootloader`](https://github.com/rust-osdev/bootloader): An experimental, pure-Rust, legacy bootloader.
 - [`bootimage`](https://github.com/rust-osdev/bootimage): A tool to transform a kernel ELF file into a bootable disk image.
 - [`multiboot2-elf64`](https://github.com/rust-osdev/multiboot2-elf64): Allows parsing the boot information of the Multiboot2 standard for ELF64 kernels.
-- [`acpi`](https://github.com/rust-osdev/acpi): Rust library for parsing ACPI tables and AML 
+- [`acpi`](https://github.com/rust-osdev/acpi): Rust library for parsing ACPI tables and AML.
+- [`uefi-rs`](https://github.com/rust-osdev/uefi-rs): Rust library for interacting with UEFI firmware.
 
 ## Contributing
 Contributions are more than welcome! If you have any suggestions, ideas, or projects you would like to host under this organization, don't hesitate to contact us!


### PR DESCRIPTION
Add the `uefi` crate to the list of `rust-osdev` projects