### PR TITLE
Goodbye, rust-osdev!

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,5 @@ The following people are currently members of this organization:
 - Isaac Woods ([@IsaacWoods](https://github.com/IsaacWoods)): Author of [Pebble OS](https://github.com/pebble-os/pebble)
 - Patrik Cyvoct ([@Sh4d1](https://github.com/Sh4d1)): Cloud and OSdev enthusiast
 - Andre Richter ([@andre-richter](https://github.com/andre-richter)): Author of [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
-- Matt Thomas ([@matthew-a-thomas](https://github.com/matthew-a-thomas)): C# developer who fell in with the wrong crowd
 - Ryland Morgan ([@rybot666](https://github.com/rybot666)): Contributor to the bootloader rewrite
 - Stefan Lankes ([@stlankes](https://github.com/stlankes/)): Contributor to the library operating system [RustyHermit](https://github.com/hermitcore/libhermit-rs)

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Contributions are more than welcome! If you have any suggestions, ideas, or proj
 ## Members
 The following people are currently members of this organization:
 
-- Philipp Oppermann ([@phil-opp](https://github.com/phil-opp)): Author of the [“Writing an OS in Rust”](https://os.phil-opp.com/) series.
-- Lachlan Sneff ([@lachlansneff](https://github.com/lachlansneff)): Author of [nebulet os](https://github.com/nebulet/nebulet).
-- Rob Gries ([@robert-w-gries](https://github.com/robert-w-gries)): Author of [rxinu](https://github.com/robert-w-gries/rxinu), a Rust implementation of the Xinu educational operating system.
-- Jiří Zárevúcky ([@le-jzr](https://github.com/le-jzr)): Contributor to [helenos](https://github.com/HelenOS/helenos).
-- Joel Wejdenstal ([@xacrimon](https://github.com/xacrimon)): Author of the [skp](https://github.com/xacrimon/skp) project.
-- Isaac Woods ([@IsaacWoods](https://github.com/IsaacWoods)): Author of [Pebble OS](https://github.com/pebble-os/pebble).
-- Patrik Cyvoct ([@Sh4d1](https://github.com/Sh4d1)): Cloud and OSdev enthusiast.
-- Andre Richter ([@andre-richter](https://github.com/andre-richter)): Author of [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials).
-- Matt Thomas ([@matthew-a-thomas](https://github.com/matthew-a-thomas)): C# developer who fell in with the wrong crowd.
+- Philipp Oppermann ([@phil-opp](https://github.com/phil-opp)): Author of the [“Writing an OS in Rust”](https://os.phil-opp.com/) series
+- Lachlan Sneff ([@lachlansneff](https://github.com/lachlansneff)): Author of [nebulet os](https://github.com/nebulet/nebulet)
+- Rob Gries ([@robert-w-gries](https://github.com/robert-w-gries)): Author of [rxinu](https://github.com/robert-w-gries/rxinu), a Rust implementation of the Xinu educational operating system
+- Jiří Zárevúcky ([@le-jzr](https://github.com/le-jzr)): Contributor to [helenos](https://github.com/HelenOS/helenos)
+- Joel Wejdenstal ([@xacrimon](https://github.com/xacrimon)): Author of the [skp](https://github.com/xacrimon/skp) project
+- Isaac Woods ([@IsaacWoods](https://github.com/IsaacWoods)): Author of [Pebble OS](https://github.com/pebble-os/pebble)
+- Patrik Cyvoct ([@Sh4d1](https://github.com/Sh4d1)): Cloud and OSdev enthusiast
+- Andre Richter ([@andre-richter](https://github.com/andre-richter)): Author of [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
+- Matt Thomas ([@matthew-a-thomas](https://github.com/matthew-a-thomas)): C# developer who fell in with the wrong crowd
 - Ryland Morgan ([@rybot666](https://github.com/rybot666)): Contributor to the bootloader rewrite
 - Stefan Lankes ([@stlankes](https://github.com/stlankes/)): Contributor to the library operating system [RustyHermit](https://github.com/hermitcore/libhermit-rs)


### PR DESCRIPTION
Thanks for the fun times!

Unfortunately I haven't been able to contribute very much to this organization and doubt that I will in the near future. I did create the `ansi_rgb` crate[^1] but that hasn't received much attention from the broader Rust community. C# pays my bills and my growing family leaves less and less time for dabbling in Rust. So I'm going to bow out.

@phil-opp your "Writing an OS in Rust" series sucked me in and taught me a lot about Rust, especially `no_std` Rust. Thank you!

- [x] Ownership of [the `ansi_rgb` crate](https://crates.io/crates/ansi_rgb) has already been set to [the `ansi_rgb` team](https://github.com/orgs/rust-osdev/teams/ansi_rgb)[^2]
- @IsaacWoods and I are working on doing the following for him:
  - [x] Join [the `ansi_rgb` team](https://github.com/orgs/rust-osdev/teams/ansi_rgb)
  - [x] Be added as an [owner](https://doc.rust-lang.org/cargo/commands/cargo-owner.html) of `ansi_rgb`
    - [x] @IsaacWoods has been invited
    - [x] Then it'll be possible to remove my ownership. Until then I get this error:
          ```
          cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required.
          ```
  - [ ] Generate [a new Cargo API token](https://crates.io/settings/tokens)
  - [ ] Paste that token into [the "CARGO_REGISTRY_TOKEN" repository secret](https://github.com/rust-osdev/ansi_rgb/settings/secrets/actions)

Let me know if anything needs to be added to this list. I'll officially leave this organization once this PR is merged.

[^1]: To get the full context behind that effort, start reading here: https://github.com/phil-opp/blog_os/issues/603
[^2]: https://github.com/rust-osdev/ansi_rgb/issues/9