### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,3 @@ Currently we are hosting the following projects:
 
 ## Contributing
 Contributions are more than welcome! If you have any suggestions, ideas, or projects you would like to host under this organization, don't hesitate to contact us!
-
-## Members
-The following people are currently members of this organization:
-
-- Philipp Oppermann ([@phil-opp](https://github.com/phil-opp)): Author of the [“Writing an OS in Rust”](https://os.phil-opp.com/) series
-- Lachlan Sneff ([@lachlansneff](https://github.com/lachlansneff)): Author of [nebulet os](https://github.com/nebulet/nebulet)
-- Rob Gries ([@robert-w-gries](https://github.com/robert-w-gries)): Author of [rxinu](https://github.com/robert-w-gries/rxinu), a Rust implementation of the Xinu educational operating system
-- Jiří Zárevúcky ([@le-jzr](https://github.com/le-jzr)): Contributor to [helenos](https://github.com/HelenOS/helenos)
-- Joel Wejdenstal ([@xacrimon](https://github.com/xacrimon)): Author of the [skp](https://github.com/xacrimon/skp) project
-- Isaac Woods ([@IsaacWoods](https://github.com/IsaacWoods)): Author of [Pebble OS](https://github.com/pebble-os/pebble)
-- Patrik Cyvoct ([@Sh4d1](https://github.com/Sh4d1)): Cloud and OSdev enthusiast
-- Andre Richter ([@andre-richter](https://github.com/andre-richter)): Author of [Operating System development tutorials in Rust on the Raspberry Pi](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
-- Ryland Morgan ([@rybot666](https://github.com/rybot666)): Contributor to the bootloader rewrite
-- Stefan Lankes ([@stlankes](https://github.com/stlankes/)): Contributor to the library operating system [RustyHermit](https://github.com/hermitcore/libhermit-rs)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,25 @@ Note that we are not an official Rust organization.
 ## Projects
 Currently we are hosting the following projects:
 
-- [`x86_64`](https://github.com/rust-osdev/x86_64): Provides general abstractions for `x86_64` systems and access to architecture specific instructions and registers.
-- [`bootloader`](https://github.com/rust-osdev/bootloader): An experimental, pure-Rust, legacy bootloader.
-- [`bootimage`](https://github.com/rust-osdev/bootimage): A tool to transform a kernel ELF file into a bootable disk image.
-- [`multiboot2-elf64`](https://github.com/rust-osdev/multiboot2-elf64): Allows parsing the boot information of the Multiboot2 standard for ELF64 kernels.
 - [`acpi`](https://github.com/rust-osdev/acpi): Rust library for parsing ACPI tables and AML.
-- [`uefi-rs`](https://github.com/rust-osdev/uefi-rs): Rust library for interacting with UEFI firmware.
 - [`ansi_rgb`](https://github.com/rust-osdev/ansi_rgb): Colorful console text using ANSI escape sequences.
+- [`bootimage`](https://github.com/rust-osdev/bootimage): A tool to transform a kernel ELF file into a bootable disk image.
+- [`bootloader`](https://github.com/rust-osdev/bootloader): An experimental, pure-Rust, legacy bootloader.
+- [`ieee1275-rs`](https://github.com/rust-osdev/ieee1275-rs): IEEE-1275/OpenFirmware Rust environment.
+- [`multiboot2`](https://github.com/rust-osdev/multiboot2): Allows parsing the boot information of the Multiboot2 standard for ELF64 kernels.
+- [`ovmf-prebuilt`](https://github.com/rust-osdev/ovmf-prebuilt): Prebuilt binaries of EDK2 firmware.
+- [`pci_types`](https://github.com/rust-osdev/pci_types): Library providing types for handling PCI/PCIe enumeration and configuration.
+- [`pic8259`](https://github.com/rust-osdev/pic8259): Abstractions for 8259 and 8259A Programmable Interrupt Controllers (PICs).
+- [`ps2-mouse`](https://github.com/rust-osdev/ps2-mouse): Library to manage a PS/2 mouse.
+- [`spinning_top`](https://github.com/rust-osdev/spinning_top): A simple spinlock crate.
+- [`uart_16550`](https://github.com/rust-osdev/uart_16550): Minimal library for uart_16550 serial output.
+- [`ucs2-rs`](https://github.com/rust-osdev/ucs2-rs): UCS2 conversion utilities.
+- [`uefi-rs`](https://github.com/rust-osdev/uefi-rs): Rust library for interacting with UEFI firmware.
+- [`usb`](https://github.com/rust-osdev/usb): Utilities for working with USB devices.
+- [`vga`](https://github.com/rust-osdev/vga): Library to program VGA hardware.
+- [`volatile`](https://github.com/rust-osdev/volatile): Provides volatile wrapper types for raw pointers.
+- [`x86_64`](https://github.com/rust-osdev/x86_64): Provides general abstractions for `x86_64` systems and access to architecture specific instructions and registers.
+- [`xhci`](https://github.com/rust-osdev/xhci): Library providing xHCI types.
 
 ## Contributing
 Contributions are more than welcome! If you have any suggestions, ideas, or projects you would like to host under this organization, don't hesitate to contact us!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # About this Organization
 
-The goal of this organization is to host and maintain all kinds of tools and libraries useful for operating system development in Rust. We're happy about everyone that wants to join us! Just drop by in our [Zulip chat](https://rust-osdev.zulipchat.com) to request an invite.
+The goal of this organization is to host and maintain all kinds of tools and libraries useful for operating system development in Rust. The organization's home page is https://rust-osdev.com, where _This Month in Rust OSDev_ is published.
+
+If you're interested in Rust and OS development, please join us on [Zulip]!
 
 Note that we are not an official Rust organization.
 
@@ -28,4 +30,6 @@ Currently we are hosting the following projects:
 - [`xhci`](https://github.com/rust-osdev/xhci): Library providing xHCI types.
 
 ## Contributing
-Contributions are more than welcome! If you have any suggestions, ideas, or projects you would like to host under this organization, don't hesitate to contact us!
+Contributions are more than welcome! If you have any suggestions, ideas, or projects you would like to host under this organization, don't hesitate to [contact us][Zulip]!
+
+[Zulip]: https://rust-osdev.zulipchat.com


### PR DESCRIPTION
* Dropped the out-of-date members list
* Updated the project list. Left out a few repos:
  * https://github.com/rust-osdev/cargo-xbuild: this appears to be a fork and hasn't been updated in two years, not sure if it's still considered active?
  * https://github.com/rust-osdev/apic: hasn't been updated in a few years, and no readme or description for me to easily copy
  * skipped archived repos
* Rephrased the text a bit to make it clearer that people should just come chat on zulip, no need to request an invite to the org itself.